### PR TITLE
Hide setting build pc tab in admin page

### DIFF
--- a/star_ecommerce/web-tinhocngoisao/wp-content/plugins/woocommerce-build-pc/views/build-pc-tab-label.php
+++ b/star_ecommerce/web-tinhocngoisao/wp-content/plugins/woocommerce-build-pc/views/build-pc-tab-label.php
@@ -1,6 +1,6 @@
 
 
-<li class="buildpc_options buildpc_tab">
+<li class="buildpc_options buildpc_tab hide_if_grouped hide_if_external">
     <a href="#buildpc_product_data"><span>
         <?php _e('Setting build PC','woocommerce-buildpc') ?>
     </span></a>


### PR DESCRIPTION
Add class to hide setting build pc tab if product is grouped or external