### PR TITLE
Update deprecated method in woocommerce version 3

### DIFF
--- a/star_ecommerce/web-tinhocngoisao/wp-content/plugins/woocommerce-build-pc/api/function.php
+++ b/star_ecommerce/web-tinhocngoisao/wp-content/plugins/woocommerce-build-pc/api/function.php
@@ -82,7 +82,7 @@ function get_products_by_custom_type(WP_REST_Request $request) {
                 if ( !$product->is_on_sale() ) {
                     $sale_price = "0";
                 }
-                $image_url = wp_get_attachment_image_src( $product->image_id, 'medium', true )[0];
+                $image_url = wp_get_attachment_image_src( $product->get_image_id(), 'medium', true )[0];
                 if ( $valid_cdn ) {
                     $image_url = str_replace( get_home_url(), $valid_cdn, $image_url );
                 }
@@ -108,7 +108,7 @@ function get_products_by_custom_type(WP_REST_Request $request) {
                         
                         foreach( $productsChildId as $productChildId ) {
                             $productChild = wc_get_product( $productChildId );
-                            $child_image_url = wp_get_attachment_image_src( $productChild->image_id, 'thumbnail', true )[0];
+                            $child_image_url = wp_get_attachment_image_src( $productChild->get_image_id(), 'thumbnail', true )[0];
                             if ( $valid_cdn ) {
                                 $child_image_url = str_replace( get_home_url(), $valid_cdn, $child_image_url );
                             }

--- a/star_ecommerce/web-tinhocngoisao/wp-content/plugins/woocommerce-hotdeal/api/lib/catalogManager.php
+++ b/star_ecommerce/web-tinhocngoisao/wp-content/plugins/woocommerce-hotdeal/api/lib/catalogManager.php
@@ -69,7 +69,7 @@ class CatalogManager {
                         $sale_price = $product->get_sale_price();
                     }
 
-                    $image_url = wp_get_attachment_image_src( $product->image_id, 'medium', true )[0];
+                    $image_url = wp_get_attachment_image_src( $product->get_image_id(), 'medium', true )[0];
                     if ( $valid_cdn ) {
                         $image_url = str_replace( get_home_url(), $valid_cdn, $image_url );
                     }

--- a/star_ecommerce/web-tinhocngoisao/wp-content/themes/online-shop-child/acmethemes/api/products/productMgr.php
+++ b/star_ecommerce/web-tinhocngoisao/wp-content/themes/online-shop-child/acmethemes/api/products/productMgr.php
@@ -202,7 +202,7 @@ if (!function_exists('get_products_by_productids')) :
 
             foreach ($productIds as $productId) {
                 if (!empty($productId)){
-                    $product = wc_get_product( $productId, 'large' );
+                    $product = wc_get_product( $productId );
                     if (!$product) {
                         continue;
                     }

--- a/star_ecommerce/web-tinhocngoisao/wp-content/themes/online-shop-child/templates/buildpc.php
+++ b/star_ecommerce/web-tinhocngoisao/wp-content/themes/online-shop-child/templates/buildpc.php
@@ -31,7 +31,7 @@
                 'link' => get_permalink( $product->product_id),
                 'regular_price' => $regular_price,
                 'sale_price' => $sale_price,
-                'image' => wp_get_attachment_image_src( $product->image_id, 'medium', true )[0],
+                'image' => wp_get_attachment_image_src( $product->get_image_id(), 'medium', true )[0],
                 'average_rating' => $product->average_rating,
                 'review_count' => $product->review_count
             );


### PR DESCRIPTION
- Remove parameter **large** in **wc_get_product**

- Use method **get_image_id** instead of property **image_id**